### PR TITLE
Fix trying to decode string token

### DIFF
--- a/applemusicpy/client.py
+++ b/applemusicpy/client.py
@@ -56,7 +56,8 @@ class AppleMusic:
             'exp': int((datetime.now() + timedelta(hours=session_length)).timestamp())  # expiration time
         }
         token = jwt.encode(payload, self._secret_key, algorithm=self._alg, headers=headers)
-        self.token_str = token.decode()
+        self.token_str = token if type(token) is not bytes else token.decode()
+
 
     def _auth_headers(self):
         """


### PR DESCRIPTION
When trying to create a token I was getting following error:

```
app_1       |   File "/usr/local/lib/python3.8/site-packages/applemusicpy/client.py", line 33, in __init__
app_1       |     self.generate_token(session_length)
app_1       |   File "/usr/local/lib/python3.8/site-packages/applemusicpy/client.py", line 59, in generate_token
app_1       |     self.token_str = token.decode()
app_1       | AttributeError: 'str' object has no attribute 'decode'
```

This should fix that error